### PR TITLE
Configuration d'une baseURL pour le flux RSS

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1,4 +1,4 @@
-baseURL = "/"
+baseURL = "https://blank.blue/"
 title = ""
 relativeURLs = true
 theme = "book"


### PR DESCRIPTION
En modifiant cette valeur pour une URL complète, cela devrait permettre à Hugo de s'y retrouver lorsqu'il génère le flux 🤞 

https://gohugo.io/getting-started/configuration/#baseurl

Note: modifier le `title` aiderait aussi à avoir une description explicite du flux dans les agrégateurs.